### PR TITLE
Fix a stray $.

### DIFF
--- a/lib/MooseX/MungeHas.pm
+++ b/lib/MooseX/MungeHas.pm
@@ -92,7 +92,7 @@ sub _compile_munger_code
 	
 	if (delete $features{"eq_1"})
 	{
-		push @code, '  my ($pfx, $name) = ($. =~ /^(_*)(.+)$/);';
+		push @code, '  my ($pfx, $name) = ($_ =~ /^(_*)(.+)$/);';
 		push @code, '  $_{builder}   = "_build_$_" if exists($_{builder}) && $_{builder} eq q(1);';
 		push @code, '  $_{clearer}   = "${pfx}clear_${name}" if exists($_{clearer}) && $_{clearer} eq q(1);';
 		push @code, '  $_{predicate} = "${pfx}has_${name}" if exists($_{predicate}) && $_{predicate} eq q(1);';


### PR DESCRIPTION
I get warnings about `Use of uninitialized value $. in pattern match (m//) at (eval 278) line 5` when using Moops with `-w`. Pretty sure that this is the culprit, and I'm pretty sure that this `$.` just got lost in 0.003's `$.`-to-`$_`-athon.
