### PR TITLE
Fix bug with `builder => sub {…}` in roles

### DIFF
--- a/lib/MooseX/MungeHas.pm
+++ b/lib/MooseX/MungeHas.pm
@@ -124,9 +124,10 @@ sub _compile_munger_code
 	push @code, '  if (ref($_{builder}) eq q(CODE)) {';
 	push @code, '    no strict qw(refs);';
 	push @code, '    require Sub::Util;';
-	push @code, '    my $name = "$_{__CALLER__}::_build_$_";';
+	push @code, '    my $short_name = "_build_$_";';
+	push @code, '    my $name = "$_{__CALLER__}::$short_name";';
 	push @code, '    *$name = Sub::Util::set_subname($name, $_{builder});';
-	push @code, '    $_{builder} = $name;';
+	push @code, '    $_{builder} = $short_name;';
 	push @code, '  }';
 	
 	unless (_detect_oo($caller) eq "Moo")

--- a/t/07rolebuildersub.t
+++ b/t/07rolebuildersub.t
@@ -1,0 +1,55 @@
+=pod
+
+=encoding utf-8
+
+=head1 PURPOSE
+
+Test C<< has attr => (builder => sub {}) >> works in a role.
+
+=head1 DEPENDENCIES
+
+Test requires Moo or is skipped.
+
+=head1 AUTHOR
+
+Aaron Crane E<lt>arc@cpan.orgE<gt>.
+
+=head1 COPYRIGHT AND LICENCE
+
+This software is copyright (c) 2017 by Aaron Crane.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut
+
+use strict;
+use warnings;
+use Test::Requires 'Moo';
+use Test::More;
+
+{
+        package Local::Role1;
+        use Moo::Role;
+        use MooseX::MungeHas;
+        has attr => (is => 'lazy', builder => sub { 'from role' });
+}
+
+{
+        package Local::Class1;
+        use Moo;
+        with 'Local::Role1';
+        sub _build_attr { 'from class' }
+}
+
+{
+        package Local::Class2;
+        use Moo;
+        with 'Local::Role1';
+        around _build_attr => sub { 'from class' };
+}
+
+is(Local::Class1->new->attr, 'from class');
+is(Local::Class2->new->attr, 'from class');
+done_testing;
+


### PR DESCRIPTION
The builder option was previously being set to the fully-qualified name of the subroutine. That meant that when the underlying object system called it, it did the equivalent of:

```perl
$self->{attr} = $self->Some::Role::_build_attr;
```

which failed to call any modified or overridden method installed by the composing class.