### PR TITLE
Quell uninitialised-value warning when no "is"

### DIFF
--- a/lib/MooseX/MungeHas.pm
+++ b/lib/MooseX/MungeHas.pm
@@ -131,13 +131,15 @@ sub _compile_munger_code
 	
 	unless (_detect_oo($caller) eq "Moo")
 	{
-		push @code, '  if ($_{is} eq q(lazy)) {';
+		push @code, '  my $is = $_{is} || "";';
+
+		push @code, '  if ($is eq q(lazy)) {';
 		push @code, '    $_{is}      = "ro";';
 		push @code, '    $_{lazy}    = 1 unless exists($_{lazy});';
 		push @code, '    $_{builder} = "_build_$_" if $_{lazy} && !exists($_{builder}) && !exists($_{default});';
 		push @code, '  }';
 		
-		push @code, '  if ($_{is} eq q(rwp)) {';
+		push @code, '  if ($is eq q(rwp)) {';
 		push @code, '    $_{is}     = "ro";';
 		push @code, '    $_{writer} = "_set_$_" unless exists($_{writer});';
 		push @code, '  }';

--- a/t/08undefbare.t
+++ b/t/08undefbare.t
@@ -1,0 +1,53 @@
+=pod
+
+=encoding utf-8
+
+=head1 PURPOSE
+
+Test C<< has '+attr' => (default => ...) >> under Moose yields no warnings.
+
+=head1 DEPENDENCIES
+
+Test requires Moose or is skipped.
+
+=head1 AUTHOR
+
+Aaron Crane E<lt>arc@cpan.orgE<gt>.
+
+=head1 COPYRIGHT AND LICENCE
+
+This software is copyright (c) 2017 by Aaron Crane.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut
+
+use strict;
+use warnings;
+use Test::Requires 'Moose';
+use Test::More;
+
+my @warnings;
+local $^W = 1;
+local $SIG{__WARN__} = sub { push @warnings, shift };
+
+{
+        package Local::Base;
+        use Moose;
+        use MooseX::MungeHas;
+        has attr => (is => 'ro', required => 1);
+}
+
+{
+        package Local::Derived;
+        use Moose;
+        use MooseX::MungeHas;
+        extends 'Local::Base';
+        has '+attr' => (default => 17);
+}
+
+is_deeply(\@warnings, [], 'no warnings issued')
+    or diag explain(\@warnings);
+done_testing;
+


### PR DESCRIPTION
Omitting `is` (rather than using `is => 'bare'`) is useful when extending an attributed defined in a base class or a role. Previously, the `has` generated by MooseX::MungeHas was emitting uninitialized-value warnings when a non-Moo class tried to do that. (Moo classes aren't affected by this, because Moo natively supports `is => 'lazy'` and `is => 'rwp'`, and so MooseX::MungeHas doesn't need to look at `is` for Moo.)

This change doesn't depend on my patch in pull request #3, but since that other patch uses test file number 7, this PR skips that number and goes to number 8.